### PR TITLE
Support new WiFiEvent_t enum in Arduino ESP32 2.0

### DIFF
--- a/src/EspSimpleWifiHandler.cpp
+++ b/src/EspSimpleWifiHandler.cpp
@@ -49,17 +49,25 @@ EspSimpleWifiHandler::EspSimpleWifiHandler(
     });
   #else // for ESP32
     WiFi.onEvent(
-      [this](WiFiEvent_t event, system_event_info_t info) {
+      [this](WiFiEvent_t event, WiFiEventInfo_t info) {
         this->_onWifiConnected();
       },
+#if ESP_ARDUINO_VERSION_MAJOR >= 2
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP
+#else
       WiFiEvent_t::SYSTEM_EVENT_STA_GOT_IP
+#endif
     );
 
     WiFi.onEvent(
-      [this](WiFiEvent_t event, system_event_info_t info) {
+      [this](WiFiEvent_t event, WiFiEventInfo_t info) {
         this->_onWifiDisconnected();
       },
+#if ESP_ARDUINO_VERSION_MAJOR >= 2
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED
+#else
       WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED
+#endif
     );
   #endif
 


### PR DESCRIPTION
This makes this library build against the 2.0.x ESP32 release.

Tested on esp32-arduino 1.0.6 and 2.0.2.